### PR TITLE
Small fixes for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+bin
+logs
+wandb
+outputs
+data
+data_local
+.vscode
+_wandb
+
+**/.DS_Store
+
+fuse.cfg
+
+*.ai
+
+# Generation results
+results/
+
+ray/auth.json
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can find all scripted/human demo for simulated environments [here](https://d
     pip install einops
     pip install packaging
     pip install h5py
-    pip install h5py_cache
+    pip install ipython
     cd act/detr && pip install -e .
 
 ### Example Usages

--- a/conda_env.yaml
+++ b/conda_env.yaml
@@ -1,0 +1,24 @@
+name: aloha
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+dependencies:
+  - python=3.9
+  - pip=23.0.1
+  - pytorch=2.0.0
+  - torchvision=0.15.0
+  - pytorch-cuda=11.8
+  - pyquaternion=0.9.9
+  - pyyaml=6.0
+  - rospkg=1.5.0
+  - pexpect=4.8.0
+  - mujoco=2.3.3
+  - dm_control=1.0.9
+  - py-opencv=4.7.0
+  - matplotlib=3.7.1
+  - einops=0.6.0
+  - packaging=23.0
+  - h5py=3.8.0
+  - pip:
+    - h5py_cache==1.0

--- a/conda_env.yaml
+++ b/conda_env.yaml
@@ -20,5 +20,4 @@ dependencies:
   - einops=0.6.0
   - packaging=23.0
   - h5py=3.8.0
-  - pip:
-    - h5py_cache==1.0
+  - ipython=8.12.0

--- a/record_sim_episodes.py
+++ b/record_sim_episodes.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import argparse
 import matplotlib.pyplot as plt
-import h5py_cache
+import h5py
 
 from constants import PUPPET_GRIPPER_POSITION_NORMALIZE_FN, SIM_TASK_CONFIGS
 from ee_sim_env import make_ee_sim_env
@@ -158,8 +158,7 @@ def main(args):
         # HDF5
         t0 = time.time()
         dataset_path = os.path.join(dataset_dir, f'episode_{episode_idx}')
-        with h5py_cache.File(dataset_path + '.hdf5', 'w', chunk_cache_mem_size=1024 ** 2 * 2) as root:
-        # with h5py.File(dataset_path + '.hdf5', 'w') as root:
+        with h5py.File(dataset_path + '.hdf5', 'w', rdcc_nbytes=1024 ** 2 * 2) as root:
             root.attrs['sim'] = True
             obs = root.create_group('observations')
             image = obs.create_group('images')


### PR DESCRIPTION
Changes:
1. Removed h5py_cache as dependency
2. Added ipython as dependency
3. Added a conda_env.yaml file that locks tested package versions.

Problem:
[h5py_cache](https://github.com/moble/h5py_cache) is deprecated with its functionality built-in to h5py. Currently h5py_cache packages installed from pip has some conflict with numpy versions. I recommed removing this dependency in favor of using h5py directly.
```
Traceback (most recent call last):
  File "record_sim_episodes.py", line 189, in <module>
    main(vars(parser.parse_args()))
  File "record_sim_episodes.py", line 161, in main
    with h5py_cache.File(dataset_path + '.hdf5', 'w', chunk_cache_mem_size=1024 ** 2 * 2) as root:
  File "/local/crv/cchi/mambaforge/envs/aloha/lib/python3.8/site-packages/h5py_cache/__init__.py", line 67, in File
    bytes_per_object = np.dtype(np.float).itemsize  # assume float as most likely
  File "/local/crv/cchi/mambaforge/envs/aloha/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```