### PR TITLE
Fix dataset folder path to include task name

### DIFF
--- a/record_sim_episodes.py
+++ b/record_sim_episodes.py
@@ -30,8 +30,6 @@ def main(args):
     inject_noise = False
     render_cam_name = 'angle'
 
-    if not os.path.isdir(dataset_dir):
-        os.makedirs(dataset_dir, exist_ok=True)
 
     episode_len = SIM_TASK_CONFIGS[task_name]['episode_len']
     camera_names = SIM_TASK_CONFIGS[task_name]['camera_names']
@@ -41,6 +39,10 @@ def main(args):
         policy_cls = InsertionPolicy
     else:
         raise NotImplementedError
+
+    dataset_dir = os.path.join(dataset_dir, task_name)
+    if not os.path.isdir(dataset_dir):
+        os.makedirs(dataset_dir, exist_ok=True)
 
     success = []
     for episode_idx in range(num_episodes):


### PR DESCRIPTION
This PR adds the task name as the sub-folder under the data collection path, so that it is compatible with the way data_dir is specified in ``constants.py``, which makes it seamless in training 

https://github.com/tonyzhaozh/act/blob/742c753c0d4a5d87076c8f69e5628c79a8cc5488/constants.py#L7